### PR TITLE
Update broken link in numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then, modify the `__src` folder contents:
 For more information about how to write Rust code that interfaces with Python, read:
 
 -   https://pyo3.rs/
--   https://rust-numpy.github.io/rust-numpy
+-   https://docs.rs/numpy/
 -   https://docs.rs/ndarray/
 
 ## Tested Python Versions


### PR DESCRIPTION
Previous link to rusty-numpy was broken. Replaced it with latest stable, but could also use current main branch https://pyo3.github.io/rust-numpy/numpy/index.html